### PR TITLE
Use "md5sum -b" style separator in generated checksum files

### DIFF
--- a/internal/checksum/checksum.go
+++ b/internal/checksum/checksum.go
@@ -41,7 +41,7 @@ func MD5Sum(filepath string) (string, error) {
 }
 
 // separator is used to separate the checksum from the filepath in the checksum file.
-const separator = "  "
+const separator = " *"
 
 // CreateChecksumFile creates a checksum file for the given file.
 // It returns the path to the created checksum file.


### PR DESCRIPTION
This PR makes the generated checksum files in a format that is expected when generating checksum files running  `md5sum`  in binary mode.