### PR TITLE
Fix nil pointer exception

### DIFF
--- a/internal/warc/testdata/corrupt.warc.gz
+++ b/internal/warc/testdata/corrupt.warc.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c13fd08626a7564c16058fabbaa3785317268e9ee3f40eac94cc9858e51864b
+size 55

--- a/internal/warc/validate.go
+++ b/internal/warc/validate.go
@@ -38,7 +38,10 @@ func IsValid(file, tmpDir string) (bool, error) {
 			return validation.Valid(), nil
 		}
 		if err != nil {
-			*validation = append(*validation, err)
+			if wr != nil {
+				defer wr.Close()
+			}
+			return false, nil
 		}
 		func() {
 			defer wr.Close()

--- a/internal/warc/validate_test.go
+++ b/internal/warc/validate_test.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	validWarcFile   = "testdata/valid.warc.gz"
-	invalidWarcFile = "testdata/invalid.warc.gz"
+	validWarcFile     = "testdata/valid.warc.gz"
+	invalidWarcFile   = "testdata/invalid.warc.gz"
+	corruptedWarcFile = "testdata/corrupt.warc.gz"
 )
 
 func TestMain(m *testing.M) {
@@ -40,6 +41,10 @@ func TestIsValid(t *testing.T) {
 		},
 		{
 			file:    invalidWarcFile,
+			isValid: false,
+		},
+		{
+			file:    corruptedWarcFile,
 			isValid: false,
 		},
 	}


### PR DESCRIPTION
This PR fixes a nil pointer exception that triggers when a corrupted file is validated.

A test with a corrupted warc file is part of this PR to avoid regressions later.